### PR TITLE
Added support for '==='.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,6 +35,13 @@ You can use this in any place a block is expected, for example to create a lambd
     normalizer.call :HelloWorld
       # => "helloworld"
 
+Last but definitly not least you can use this as a target for `when` like this
+
+    case( something )
+    when X.respond_to? :foo then "something responds to :foo"
+    when X.kind_of? Hash then "something is a Hash"
+    end
+
 Gotchas
 -------
 
@@ -63,6 +70,15 @@ Secondly, other arguments or operands will only be evaluated once, and not every
     i = 0
     [1, 2].map{ |x| x + (i += 1) }
       # => [2, 4]
+
+
+Thirdly, `#===` only works on `X` itself.
+
+    # Correct
+    [1,2,3].map(&X === 2) #=> [false, true, false]
+
+    # Wrong:
+    [1,2,3].map(&X.class === Fixnum) #! raises an exception
 
 Epilogue
 --------

--- a/lib/ampex.rb
+++ b/lib/ampex.rb
@@ -23,6 +23,17 @@ class Metavariable < superclass
     @to_proc = block || ::Proc.new{|x| x}
   end
 
+  # This method is here so that a metavariable can be used as a target for "when" like this:
+  #
+  #   case( foo )
+  #   when X.respond_to? :bar then "Responds to :bar"
+  #   when X.respond_to? :foobar then "Responds to :foobar"
+  #   end
+  #
+  def ===(y)
+    to_proc === y
+  end
+
   # Each time a method is called on a Metavariable, we want to create a new
   # Metavariable that is like the last but does something more.
   #
@@ -42,8 +53,11 @@ class Metavariable < superclass
   # BlankSlate and BasicObject have different sets of methods that you don't want.
   # let's remove them all.
   instance_methods.each do |method|
-    undef_method method unless %w(method_missing to_proc __send__ __id__).include? method.to_s
+    undef_method method unless %w(method_missing to_proc __send__ __id__ ===).include? method.to_s
   end
 end
 
 X = Metavariable.new
+class << X
+  undef ===
+end

--- a/spec/ampex_spec.rb
+++ b/spec/ampex_spec.rb
@@ -55,4 +55,17 @@ describe "&X" do
     [A.new].map(&X.sign_off).should == ["Yours relatedly, Cousin Sybil"]
   end
 
+  it "should be a valid target for when" do
+
+    (X.kind_of?(Numeric) === "String").should be_false
+
+  end
+
+  it "should not override X#===" do
+
+    [1,2,3].map(&X === 2).should == [false, true, false]
+
+  end
+
+
 end


### PR DESCRIPTION
Hi

I know this change is not 100% backward compatible, but the syntax is very tempting. I've implemented `===` on `Metavariable` so that it can be used as a target for `when`. Look a this example:

``` ruby
case( something )
when X.respond_to? :foo then "something responds to :foo"
when X.kind_of? Hash then "something is a Hash"
end
```

I think this would be a really cool feature, wouldn't it?

Cheers'
Hannes
